### PR TITLE
Remove duplicate 'abort()' call

### DIFF
--- a/cpp/src/securemessage/secure_message_wrapper.cc
+++ b/cpp/src/securemessage/secure_message_wrapper.cc
@@ -142,7 +142,6 @@ int SecureMessageWrapper::GetEncScheme(CryptoOps::EncType enc_type) {
 
   // This should never happen and is undefined behavior if it does.
   Util::LogErrorAndAbort("wrong enctype");
-  abort();
 }
 
 }  // namespace securemessage


### PR DESCRIPTION
The `util::LogErrorAndAbort()` function calls `abort()`, so this instance is an unnecessary duplicate.